### PR TITLE
fix: Fix incorrect party during Investigation power

### DIFF
--- a/backend/src/main/java/game/SecretHitlerGame.java
+++ b/backend/src/main/java/game/SecretHitlerGame.java
@@ -310,9 +310,7 @@ public class SecretHitlerGame implements Serializable {
             throw new IllegalStateException("Cannot assign roles with too many players.");
         }
 
-        // 5 6 7 8 9 10
-        int[] fascistsFromPlayers = new int[] { 1, 1, 2, 2, 3, 3 };
-        int numFascistsToSet = fascistsFromPlayers[players - MIN_PLAYERS];
+        int numFascistsToSet = NUM_FASCISTS_FOR_PLAYERS[players];
 
         // Set all players to default state
         for (Player player : playerList) {

--- a/backend/src/main/java/server/SecretHitlerServer.java
+++ b/backend/src/main/java/server/SecretHitlerServer.java
@@ -675,6 +675,7 @@ public class SecretHitlerServer {
                         } else {
                             obj.put(PARAM_INVESTIGATION, LIBERAL);
                         }
+                        obj.put(PARAM_TARGET, message.getString(PARAM_TARGET));
                         ctx.send(obj.toString());
                         break;
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -68,7 +68,7 @@ import {
     WEBSOCKET_HEADER,
     DEBUG,
     PACKET_PONG,
-    PING_INTERVAL, COMMAND_PING, SERVER_PING, PARAM_ICON, PARAM_DID_VETO_OCCUR
+    PING_INTERVAL, COMMAND_PING, SERVER_PING, PARAM_ICON, PARAM_DID_VETO_OCCUR, PARAM_INVESTIGATION
 } from "./GlobalDefinitions";
 
 import PlayerDisplay, {
@@ -415,7 +415,17 @@ class App extends Component {
                 break;
 
             case PACKET_INVESTIGATION:
+                // Trigger investigation screen when the server responds.
+                console.log("Investigated player role: " + message[PARAM_INVESTIGATION]);
+                // Set party to liberal/fascist using sent packet
+                const party = (message[PARAM_INVESTIGATION]);
 
+                this.queueAlert(
+                    <InvestigationAlert party={party}
+                                        target={message[PARAM_TARGET]}
+                                        hideAlert={this.hideAlertAndFinish}
+                    />
+                    , false);
                 break;
             case PACKET_PONG:
             default:
@@ -1154,17 +1164,8 @@ class App extends Component {
                                     </ButtonPrompt>
                                     , true);
                             } else {
-                                // Is President
-                                let target = newState[PARAM_TARGET];
-                                // Set party according to liberal/fascist
-                                let party = (newState[PARAM_PLAYERS][target][PLAYER_IDENTITY] === LIBERAL ? LIBERAL : FASCIST);
-
-                                this.queueAlert(
-                                    <InvestigationAlert party={party}
-                                                        target={target}
-                                                        hideAlert={this.hideAlertAndFinish}
-                                    />
-                                    , false);
+                                // Is President; do nothing because we handle the
+                                // response directly from the server.
                             }
                             break;
                         case STATE_PP_PEEK: // No additional case is necessary for peeking.


### PR DESCRIPTION
Fixes #84, "President [Investigation] shows wrong loyalty".

This was caused by a bad assumption on the original Investigation prompt card, which assumed it had access to all player roles (which is untrue as of the most recent update). I've changed it so that the prompt gets its data from a packet sent by the server instead, which I think was what it was originally supposed to do.

I've tested this change locally and can confirm that I get the correct role as both Liberal and Fascist players.