### PR TITLE
 Progressive Web App  name fix

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Secret Hitler",
+  "name": "Secret Hitler Online",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
# Problem

On installing the Progressive Web App on a computer or phone, the name shows as "Create React App Sample"



# Solution

Fixed name manifest.json

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Change summary:

Updated frontend/manifest.json with the right name 

## Steps to Verify:

1. Open the app in Chrome on a computer or an Android Mobile browser
2. Click on the install icon
3. Check the name of the app that is installed

## Screenshots (optional):
<img width="512" alt="image" src="https://github.com/user-attachments/assets/08047e15-f2de-4e55-9c21-5882362c6ca8" />

## Keyfiles 
1. frontend/public/manifest.json