### PR TITLE
Add docker-compose.yml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# Must use Unix-style line endings (LF) for compatibility with the
+# docker-compose quickstart on Windows. CRLF line endings will cause the
+# script to fail when run in the container environment.
+backend/gradlew text eol=lf
 *.svg binary

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,9 +2,9 @@
 
 ## Quick start using Docker:
 - Run everything with Docker Compose (DB + backend + frontend):
-  - docker compose up --build
-  - Open frontend: http://localhost:3000
-  - Backend health: http://localhost:4040/ping
+  - `docker compose up --build`
+  - Open frontend: [http://localhost:3000](http://localhost:3000)
+  - Backend health: [http://localhost:4040/ping](http://localhost:4040/ping)
 - Alternative: only DB in Docker, run app locally:
   - docker compose up -d db  (or use docker run …)
   - export DATABASE_URL=postgres://secret:secret@localhost:5432/secrethitler

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,16 @@
 # Development setup for Secret Hitler Online
 
+## Quick start using Docker:
+- Run everything with Docker Compose (DB + backend + frontend):
+  - docker compose up --build
+  - Open frontend: http://localhost:3000
+  - Backend health: http://localhost:4040/ping
+- Alternative: only DB in Docker, run app locally:
+  - docker compose up -d db  (or use docker run …)
+  - export DATABASE_URL=postgres://secret:secret@localhost:5432/secrethitler
+  - In backend/: ./gradlew runLocal
+  - In frontend/: npm install && npm run devLocal
+
 Your setup will vary depending on if you're only making changes to the frontend, or if you're making changes to the frontend and the backend at once.
 
 ## Frontend Only
@@ -18,7 +29,7 @@ npm install
 npm run devServer
 ```
 
-The webpage should open automatically in your browser, but is usually hosted at [localhost:3000](http://locahost:3000).
+The webpage should open automatically in your browser, but is usually hosted at [localhost:3000](http://localhost:3000).
 
 ## Changing frontend + backend
 
@@ -35,7 +46,7 @@ cd Secret-Hitler-Online/backend
 ./gradlew runLocal
 ```
 
-This will start the backend server at [`http://localhost:4040`](http://locahost:4040) by default. This will also set the server in debug-mode, so the CORS policy will not block access from the frontend.
+This will start the backend server at [`http://localhost:4040`](http://localhost:4040) by default. This will also set the server in debug-mode, so the CORS policy will not block access from the frontend.
 
 **Every time you make changes to Java files, you'll need to stop and restart the development server.**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,10 +6,11 @@
   - Open frontend: [http://localhost:3000](http://localhost:3000)
   - Backend health: [http://localhost:4040/ping](http://localhost:4040/ping)
 - Alternative: only DB in Docker, run app locally:
-  - docker compose up -d db  (or use docker run …)
-  - export DATABASE_URL=postgres://secret:secret@localhost:5432/secrethitler
-  - In backend/: ./gradlew runLocal
-  - In frontend/: npm install && npm run devLocal
+  - `docker compose up -d db`  (or use docker run …)
+  - `export DATABASE_URL=postgres://secret:secret@localhost:5432/secrethitler`
+  - In backend/: `./gradlew runLocal`
+  - In frontend/: `npm install && npm run devLocal`
+  - Open frontend: [http://localhost:3000](http://localhost:3000)
 
 Your setup will vary depending on if you're only making changes to the frontend, or if you're making changes to the frontend and the backend at once.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  db:
+    image: postgres:15
+    container_name: sh-postgres
+    environment:
+      POSTGRES_USER: secret
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: secrethitler
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U secret -d secrethitler"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    image: gradle:8.6.0-jdk17
+    container_name: sh-backend
+    working_dir: /app/backend
+    volumes:
+      - ./backend:/app/backend
+      - gradle-cache:/home/gradle/.gradle
+    environment:
+      DEBUG_MODE: "true"
+      DATABASE_URL: postgres://secret:secret@db:5432/secrethitler
+      PORT: "4040"
+    command: ["bash", "-lc", "./gradlew runLocal"]
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "4040:4040"
+
+  frontend:
+    image: node:18
+    container_name: sh-frontend
+    working_dir: /app/frontend
+    volumes:
+      - ./frontend:/app/frontend
+    environment:
+      HOST: 0.0.0.0
+      CHOKIDAR_USEPOLLING: "true"
+    command: bash -lc "npm install && npm run devLocal"
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+
+volumes:
+  gradle-cache: {}


### PR DESCRIPTION
# Problem
Local setup required running multiple manual commands for database, backend, and frontend. This made onboarding and development more complex.

# Solution
- Added `docker-compose.yml` to run **DB + backend + frontend** together with a single command.  
- Updated `DEVELOPMENT.md` with quick start instructions (`docker compose up --build`).  
- Fixed small typos in documentation.

## Type of change
- New feature (non-breaking change which adds functionality)
- Documentation update

## Change summary:
- Added `docker-compose.yml` with services: `db`, `backend`, `frontend`  
- Configured healthcheck for Postgres  
- Mounted project folders for live code changes  
- Documented usage in `DEVELOPMENT.md`  
- Corrected localhost URL typos in docs

## Steps to Verify:
1. Run `docker compose up --build` in project root  
2. Open frontend at http://localhost:3000  
3. Check backend health at http://localhost:4040/ping  
4. Verify DB is running on port 5432  

## Screenshots (optional):
*(Add if needed, e.g., running containers or frontend page)*

## Keyfiles:
- `docker-compose.yml`  
- `DEVELOPMENT.md`

Thanks for contributing!
