### PR TITLE
feat: customizable lobby size for bot games (Fixes #180)

### DIFF
--- a/backend/src/main/java/server/SecretHitlerServer.java
+++ b/backend/src/main/java/server/SecretHitlerServer.java
@@ -39,6 +39,7 @@ public class SecretHitlerServer {
     public static final String PARAM_VETO = "veto";
     public static final String PARAM_CHOICE = "choice"; // the index of the chosen policy.
     public static final String PARAM_ICON = "icon";
+    public static final String PARAM_MIN_LOBBY_SIZE = "minLobbySize";
 
     // Passed to client
     // The type of the packet tells the client how to parse the contents.

--- a/backend/src/main/java/server/SecretHitlerServer.java
+++ b/backend/src/main/java/server/SecretHitlerServer.java
@@ -694,6 +694,14 @@ public class SecretHitlerServer {
                         String iconId = message.getString(PARAM_ICON);
                         lobby.trySetUserIcon(iconId, ctx);
                         break;
+                    
+                    case COMMAND_SET_LOBBY_SIZE:
+                        // Ensure the game hasn't started yet
+                        if (!lobby.isInGame()) {
+                            int newSize = message.getInt("size"); 
+                            lobby.setTargetLobbySize(newSize);
+                        }
+                        break;
 
                     default: // This is an invalid command.
                         throw new RuntimeException("unrecognized command " + message.get(PARAM_COMMAND));

--- a/backend/src/main/java/server/SecretHitlerServer.java
+++ b/backend/src/main/java/server/SecretHitlerServer.java
@@ -699,7 +699,7 @@ public class SecretHitlerServer {
                         // Ensure the game hasn't started yet
                         if (!lobby.isInGame()) {
                             int newSize = message.getInt("size"); 
-                            lobby.setTargetLobbySize(newSize);
+                            lobby.setMinLobbySize(newSize);
                         }
                         break;
 

--- a/backend/src/main/java/server/util/Lobby.java
+++ b/backend/src/main/java/server/util/Lobby.java
@@ -399,7 +399,7 @@ public class Lobby implements Serializable {
             message = new JSONObject();
             message.put(SecretHitlerServer.PARAM_PACKET_TYPE, SecretHitlerServer.PACKET_LOBBY);
             message.put("usernames", activeUsernames.toArray());
-            message.put("minLobbySize", minLobbySize);
+            message.put(SecretHitlerServer.PARAM_MIN_LOBBY_SIZE, minLobbySize);
         }
         // Add user icons to the update message
         JSONObject icons = new JSONObject(usernameToIcon);

--- a/backend/src/main/java/server/util/Lobby.java
+++ b/backend/src/main/java/server/util/Lobby.java
@@ -55,6 +55,13 @@ public class Lobby implements Serializable {
 
     static String DEFAULT_ICON = "p_default";
 
+    private int targetLobbySize = SecretHitlerGame.MIN_PLAYERS;
+    synchronized public void setTargetLobbySize(int size) {
+        if (size >= SecretHitlerGame.MIN_PLAYERS && size <= SecretHitlerGame.MAX_PLAYERS) {
+            this.targetLobbySize = size;
+        }
+    }
+
     /**
      * Constructs a new Lobby.
      */
@@ -392,6 +399,7 @@ public class Lobby implements Serializable {
             message = new JSONObject();
             message.put(SecretHitlerServer.PARAM_PACKET_TYPE, SecretHitlerServer.PACKET_LOBBY);
             message.put("usernames", activeUsernames.toArray());
+            message.put("targetLobbySize", targetLobbySize);
         }
         // Add user icons to the update message
         JSONObject icons = new JSONObject(usernameToIcon);
@@ -494,11 +502,11 @@ public class Lobby implements Serializable {
         usersInGame.clear();
         usersInGame.addAll(userToUsername.values());
 
-        // Generate CpuPlayers if the lobby size has not been met
+        // Generate CpuPlayers if the target lobby size has not been met
         List<String> cpuNames = new ArrayList<>();
         cpuPlayers.clear();
-        if (usersInGame.size() < SecretHitlerGame.MIN_PLAYERS) {
-            int numCpuPlayersToGenerate = SecretHitlerGame.MIN_PLAYERS - usersInGame.size();
+        if (usersInGame.size() < targetLobbySize) {
+            int numCpuPlayersToGenerate = targetLobbySize - usersInGame.size();
             int i = 1;
             while (numCpuPlayersToGenerate > 0) {
                 String botName = "Bot " + i;

--- a/backend/src/main/java/server/util/Lobby.java
+++ b/backend/src/main/java/server/util/Lobby.java
@@ -55,10 +55,10 @@ public class Lobby implements Serializable {
 
     static String DEFAULT_ICON = "p_default";
 
-    private int targetLobbySize = SecretHitlerGame.MIN_PLAYERS;
-    synchronized public void setTargetLobbySize(int size) {
+    private int minLobbySize = SecretHitlerGame.MIN_PLAYERS;
+    synchronized public void setMinLobbySize(int size) {
         if (size >= SecretHitlerGame.MIN_PLAYERS && size <= SecretHitlerGame.MAX_PLAYERS) {
-            this.targetLobbySize = size;
+            this.minLobbySize = size;
         }
     }
 
@@ -399,7 +399,7 @@ public class Lobby implements Serializable {
             message = new JSONObject();
             message.put(SecretHitlerServer.PARAM_PACKET_TYPE, SecretHitlerServer.PACKET_LOBBY);
             message.put("usernames", activeUsernames.toArray());
-            message.put("targetLobbySize", targetLobbySize);
+            message.put("minLobbySize", minLobbySize);
         }
         // Add user icons to the update message
         JSONObject icons = new JSONObject(usernameToIcon);
@@ -505,8 +505,8 @@ public class Lobby implements Serializable {
         // Generate CpuPlayers if the target lobby size has not been met
         List<String> cpuNames = new ArrayList<>();
         cpuPlayers.clear();
-        if (usersInGame.size() < targetLobbySize) {
-            int numCpuPlayersToGenerate = targetLobbySize - usersInGame.size();
+        if (usersInGame.size() < minLobbySize) {
+            int numCpuPlayersToGenerate = minLobbySize - usersInGame.size();
             int i = 1;
             while (numCpuPlayersToGenerate > 0) {
                 String botName = "Bot " + i;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import {
   SERVER_PING,
   PARAM_ICON,
   PARAM_INVESTIGATION,
+  PARAM_MIN_LOBBY_SIZE,
 } from "./constants";
 
 import PlayerDisplay, {
@@ -431,7 +432,7 @@ class App extends Component<{}, AppState> {
           usernames: message[PARAM_USERNAMES],
           icons: message[PARAM_ICON],
           page: PAGE.LOBBY,
-          minLobbySize: message["minLobbySize"] || 5,
+          minLobbySize: message[PARAM_MIN_LOBBY_SIZE] || 5,
         });
         if (message[PARAM_ICON][this.state.name] === defaultPortrait) {
           this.showChangeIconAlert();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -146,6 +146,7 @@ type AppState = {
   lobbyFromURL: boolean;
   usernames: string[];
   icons: { [key: string]: string };
+  targetLobbySize: number;
   gameState: GameState;
   /* Stores the last gameState[PARAM_STATE] value to check for changes. */
   lastState: any;
@@ -177,6 +178,7 @@ const defaultAppState: AppState = {
   lobbyFromURL: false,
   usernames: [],
   icons: {},
+  targetLobbySize: 5,
   gameState: DEFAULT_GAME_STATE,
   lastState: {},
   liberalPolicies: 0,
@@ -429,6 +431,7 @@ class App extends Component<{}, AppState> {
           usernames: message[PARAM_USERNAMES],
           icons: message[PARAM_ICON],
           page: PAGE.LOBBY,
+          targetLobbySize: message["targetLobbySize"] || 5,
         });
         if (message[PARAM_ICON][this.state.name] === defaultPortrait) {
           this.showChangeIconAlert();
@@ -917,9 +920,32 @@ class App extends Component<{}, AppState> {
           <div id={"lobby-lower-container"}>
             <div id={"lobby-player-area-container"}>
               <div id={"lobby-player-text-choose-container"}>
-                <p id={"lobby-player-count-text"}>
-                  Players ({this.state.usernames.length}/10)
-                </p>
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                  <p id={"lobby-player-count-text"}>
+                    Players ({this.state.usernames.length}/{this.state.targetLobbySize})
+                  </p>
+                  
+                  {isVIP ? (
+                    <div style={{ marginTop: "5px", display: "flex", alignItems: "center", color: "white" }}>
+                      <label style={{ marginRight: "10px" }}>Target Game Size:</label>
+                      <select 
+                        value={this.state.targetLobbySize} 
+                        onChange={(e) => this.sendWSCommand({ 
+                          command: WSCommandType.SET_LOBBY_SIZE, 
+                          size: parseInt(e.target.value) 
+                        })}
+                        style={{ padding: "5px", borderRadius: "4px", backgroundColor: "#333", color: "white", border: "1px solid #555" }}
+                      >
+                        {[5, 6, 7, 8, 9, 10].map(n => <option key={n} value={n}>{n} Players</option>)}
+                      </select>
+                    </div>
+                  ) : (
+                    <p style={{ marginTop: "5px", color: "gray", fontSize: "0.9em" }}>
+                      Target Game Size: {this.state.targetLobbySize}
+                    </p>
+                  )}
+                </div>
+
                 <button
                   id={"lobby-change-icon-button"}
                   onClick={this.onClickChangeIcon}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -146,7 +146,7 @@ type AppState = {
   lobbyFromURL: boolean;
   usernames: string[];
   icons: { [key: string]: string };
-  targetLobbySize: number;
+  minLobbySize: number;
   gameState: GameState;
   /* Stores the last gameState[PARAM_STATE] value to check for changes. */
   lastState: any;
@@ -178,7 +178,7 @@ const defaultAppState: AppState = {
   lobbyFromURL: false,
   usernames: [],
   icons: {},
-  targetLobbySize: 5,
+  minLobbySize: 5,
   gameState: DEFAULT_GAME_STATE,
   lastState: {},
   liberalPolicies: 0,
@@ -431,7 +431,7 @@ class App extends Component<{}, AppState> {
           usernames: message[PARAM_USERNAMES],
           icons: message[PARAM_ICON],
           page: PAGE.LOBBY,
-          targetLobbySize: message["targetLobbySize"] || 5,
+          minLobbySize: message["minLobbySize"] || 5,
         });
         if (message[PARAM_ICON][this.state.name] === defaultPortrait) {
           this.showChangeIconAlert();
@@ -920,32 +920,9 @@ class App extends Component<{}, AppState> {
           <div id={"lobby-lower-container"}>
             <div id={"lobby-player-area-container"}>
               <div id={"lobby-player-text-choose-container"}>
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
-                  <p id={"lobby-player-count-text"}>
-                    Players ({this.state.usernames.length}/{this.state.targetLobbySize})
-                  </p>
-                  
-                  {isVIP ? (
-                    <div style={{ marginTop: "5px", display: "flex", alignItems: "center", color: "white" }}>
-                      <label style={{ marginRight: "10px" }}>Target Game Size:</label>
-                      <select 
-                        value={this.state.targetLobbySize} 
-                        onChange={(e) => this.sendWSCommand({ 
-                          command: WSCommandType.SET_LOBBY_SIZE, 
-                          size: parseInt(e.target.value) 
-                        })}
-                        style={{ padding: "5px", borderRadius: "4px", backgroundColor: "#333", color: "white", border: "1px solid #555" }}
-                      >
-                        {[5, 6, 7, 8, 9, 10].map(n => <option key={n} value={n}>{n} Players</option>)}
-                      </select>
-                    </div>
-                  ) : (
-                    <p style={{ marginTop: "5px", color: "gray", fontSize: "0.9em" }}>
-                      Target Game Size: {this.state.targetLobbySize}
-                    </p>
-                  )}
-                </div>
-
+                <p id={"lobby-player-count-text"}>
+                  Players ({this.state.usernames.length}/{this.state.minLobbySize})
+                </p>
                 <button
                   id={"lobby-change-icon-button"}
                   onClick={this.onClickChangeIcon}
@@ -953,6 +930,40 @@ class App extends Component<{}, AppState> {
                   CHANGE ICON
                 </button>
               </div>
+
+              <div style={{ marginBottom: "15px", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+            {isVIP ? (
+              <>
+                <label style={{ color: "white", display: "flex", alignItems: "center", cursor: "pointer" }}>
+                  <span style={{ marginRight: "10px" }}>Game Size:</span>
+                  <select 
+                    value={this.state.minLobbySize} 
+                    onChange={(e) => this.sendWSCommand({ 
+                      command: WSCommandType.SET_LOBBY_SIZE, 
+                      size: parseInt(e.target.value) 
+                    })}
+                    style={{ padding: "5px", borderRadius: "4px", backgroundColor: "#333", color: "white", border: "1px solid #555", cursor: "pointer" }}
+                  >
+                    {[5, 6, 7, 8, 9, 10].map(n => (
+                      <option key={n} value={n}>
+                        {n === 10 ? "10 Players" : `${n}+ Players`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span style={{ color: "#aaaaaa", fontSize: "0.8em", marginTop: "4px" }}>
+                  (Empty spots will be filled by bots)
+                </span>
+              </>
+            ) : (
+              <p style={{ color: "gray", fontSize: "0.9em", margin: 0 }}>
+                Game Size: {this.state.minLobbySize === 10 ? "10 Players" : `${this.state.minLobbySize}+ Players`}
+                <br/>
+                <span style={{ fontSize: "0.9em" }}>(Empty spots will be filled by bots)</span>
+              </p>
+            )}
+          </div>
+
               <div id={"lobby-player-container"}>{this.renderPlayerList()}</div>
             </div>
 

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -90,6 +90,7 @@ export const STATE_FASCIST_VICTORY_ELECTION = "FASCIST_VICTORY_ELECTION"; // Fas
 // Lobby
 export const PARAM_USER_COUNT = "user-count";
 export const PARAM_USERNAMES = "usernames";
+export const PARAM_MIN_LOBBY_SIZE = "minLobbySize";
 
 // Peek
 export const PARAM_PEEK = "peek";

--- a/frontend/src/types/commands.ts
+++ b/frontend/src/types/commands.ts
@@ -3,6 +3,7 @@ export const enum WSCommandType {
   PING = "ping",
   START_GAME = "start-game",
   GET_STATE = "get-state",
+  SET_LOBBY_SIZE = "set-lobby-size",
   REGISTER_CHANCELLOR_VETO = "chancellor-veto",
   REGISTER_PRESIDENT_VETO = "president-veto",
   REGISTER_PEEK = "register-peek",
@@ -25,6 +26,7 @@ export const enum WSCommandType {
 export type ServerRequestPayload =
   | { command: WSCommandType.PING }
   | { command: WSCommandType.START_GAME }
+  | { command: WSCommandType.SET_LOBBY_SIZE; size: number }
   | { command: WSCommandType.GET_STATE }
   | { command: WSCommandType.REGISTER_CHANCELLOR_VETO }
   | { command: WSCommandType.REGISTER_PRESIDENT_VETO; veto: boolean }


### PR DESCRIPTION
# Problem

Currently, the game only generates bots to fulfill the minimum required player count (5 players). Users cannot choose to play larger games (e.g., 7 or 10 players) filled primarily with bots. This PR addresses [[Issue #180](https://github.com/ShrimpCryptid/Secret-Hitler-Online/issues/180)] to allow the lobby host to set a custom target game size that the server will auto-fill with bot players.

# Solution

I introduced a `targetLobbySize` variable to the lobby state and updated the bot generation logic in `Lobby.java` to fill the lobby up to this target size rather than the hardcoded `MIN_PLAYERS`. I also wired up a pre-existing but unused `COMMAND_SET_LOBBY_SIZE` WebSocket command in the backend and added a dropdown UI to the frontend for the lobby host to control this setting. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Change summary:

- Added `targetLobbySize` state tracking to the Java backend and modified bot generation math.
- Wired up the `set-lobby-size` WebSocket command in `SecretHitlerServer.java` to update the lobby size securely.
- Registered the new WebSocket command payload in the TypeScript definitions (`commands.ts`).
- Added a dropdown UI in `App.tsx` for the host (VIP) to adjust the target game size.
- Synchronized the target size state across all connected clients via the `PACKET_LOBBY` payload so non-hosts can view the updated settings.

## Steps to Verify:

1. Start both the Java backend (in debug mode via `$env:DEBUG_MODE="true"; ./gradlew run`) and the React frontend.
2. In your primary browser window, create a new lobby and verify that a "Target Game Size" dropdown appears, defaulting to 5.
3. Change the dropdown value to a larger number (e.g., 8).
4. Open an Incognito/Private window and join the same lobby. Verify that this non-host player sees the static text `Target Game Size: 8` and that it updates dynamically if the host changes it again.
5. Have all human players select an icon, then click "Start Game" from the host window.
6. **Expected behavior:** The game should start and the player list should reflect the total number of human players plus enough newly generated bots to exactly match the target game size selected by the host. (e.g., 2 Humans + 6 Bots = 8 Player Game).

## Screenshots:

*(screenshots showing the new dropdown in the lobby UI and the generated bots in-game)*

1. Dropdown in the lobby UI for ***Host***: <img width="1634" height="928" alt="Screenshot 2026-04-26 150103" src="https://github.com/user-attachments/assets/52266790-508e-430c-befa-39e8fc3a48d0" />

2. Dropdown in the lobby UI for ***non-host player***: <img width="1532" height="971" alt="Screenshot 2026-04-26 150202" src="https://github.com/user-attachments/assets/4621b1cf-d7f7-4600-bb8b-734f279599c5" />

3. Generated bots in-game for Host: <img width="1919" height="968" alt="Screenshot 2026-04-26 150244" src="https://github.com/user-attachments/assets/6bec8c76-c1ca-409c-b338-67e6f1315c42" />

5. Generated bots in-game for non-host: <img width="1919" height="967" alt="Screenshot 2026-04-26 150305" src="https://github.com/user-attachments/assets/652cb543-f1ce-4dac-a4ad-fbe8081cfc17" />

## Keyfiles:

1. `backend/src/
main/java/server/SecretHitlerServer.java`
2. `backend/src/main/java/server/util/Lobby.java`
3. `frontend/src/App.tsx`
4. `frontend/src/types/commands.ts`