### PR TITLE
Fix endgame role mask bug on 5th policy liberal victory

### DIFF
--- a/backend/src/main/java/game/SecretHitlerGame.java
+++ b/backend/src/main/java/game/SecretHitlerGame.java
@@ -843,6 +843,9 @@ public class SecretHitlerGame implements Serializable {
             lastPresident = null;
             return;
         }
+        
+        checkIfGameOver();
+        if (hasGameFinished()) return;
 
         this.lastState = this.state;
         switch (board.getActivatedPower()) {

--- a/backend/src/main/java/server/util/Lobby.java
+++ b/backend/src/main/java/server/util/Lobby.java
@@ -314,10 +314,6 @@ public class Lobby implements Serializable {
         }
 
         // Check if the game ended.
-        if (game != null && game.hasGameFinished()) {
-            game = null;
-            cpuPlayers.clear();
-        }
 
         // Update all the CpuPlayers so they can act
         boolean didCpuUpdateState = false;
@@ -363,6 +359,10 @@ public class Lobby implements Serializable {
             if (timerSchedulingAttempts == MAX_TIMER_SCHEDULING_ATTEMPTS) {
                 logger.error("Failed to schedule timer for CPU ticks.");
             }
+        }
+        if (game != null && game.hasGameFinished()) {
+            game = null;
+            cpuPlayers.clear();
         }
     }
 


### PR DESCRIPTION
# Problem

Fixes #164 
Fixes #157 I think

On a 5-policy Liberal victory, the game-over screen hides the true roles of all other players (rendering them blank or defaulting them to Fascist identities). This happens due to a race condition where the game instance state is completely nullified mid-flight inside `Lobby.java` before all players' outbound WebSocket frames finish serialization, combined with a state-machine issue where policy placement logic overwrites the victory status with a standard gameplay phase before the final broadcast evaluation.

# Solution

1. **State Preservation:** Modified `SecretHitlerGame.onEnactPolicy()` to run `checkIfGameOver()` and return early if a victory condition is met, preventing the victory state from being immediately overwritten by subsequent gameplay cycles.
2. **Delayed Session Cleanup:** Refactored `Lobby.updateAllUsers()` to move the game session deletion block (`game = null`) to the absolute bottom of the method. This ensures every connected user's WebSocket connection finishes broadcasting unmasked identities before the state memory is torn down.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Change summary:

- Fix endgame role mask bug on 5th policy liberal victory
- Refactor Lobby updates to broadcast unmasked roles prior to session nullification

## Steps to Verify:

1. Launch the application locally using `docker-compose up --build`.
2. Open multiple browser tabs/windows to fill a match lobby with human players and/or CPU bots. (IT TOOK ME THREE)
3. Advance the match until the Liberal team successfully enacts their 5th and final policy on the board. (TOOK FOREVER js open three tabs the bots are too good for a predictable outcome)
4. **Expected behavior:** The final screen accurately renders the true unmasked identities (Liberal, Fascist, or Hitler) for all active players and bots seamlessly across all connected clients.
5. **Suggestions for testing:** Temporarily set `LIBERAL_POLICIES_TO_WIN = 1` in your game rules configuration to test the victory end-screen state instantly.

## Keyfiles:

1. `backend/src/main/java/game/SecretHitlerGame.java`
2. `backend/src/main/java/server/util/Lobby.java`